### PR TITLE
UpdateServicesDSC/UpdateServicesServer - Fix Multiple Languages comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Update for HQRM standard
 - Changes to Project layout
 - Fixed: ClientTargetMode should be properly set
-
+- Fixed: Fix multiple language comparison test
 ## 1.0.75.0
 
 - bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Update for HQRM standard
 - Changes to Project layout
+- Fixed: ClientTargetMode should be properly set
 
 ## 1.0.75.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Update for HQRM standard
 - Changes to Project layout
+- Fix Multiple Language Comparison Test
 
 ## 1.0.75.0
 

--- a/DSCResources/MSFT_UpdateServicesServer/MSFT_UpdateServicesServer.psm1
+++ b/DSCResources/MSFT_UpdateServicesServer/MSFT_UpdateServicesServer.psm1
@@ -123,7 +123,7 @@ function Get-TargetResource
         }
         else
         {
-            $Languages = $WsusConfiguration.GetEnabledUpdateLanguages() | Out-String
+            $Languages = $WsusConfiguration.GetEnabledUpdateLanguages()
         }
         Write-Verbose -Message "WSUSServer languages are $Languages"
 
@@ -298,7 +298,7 @@ function Set-TargetResource
 
         [Parameter()]
         [System.String[]]
-        $Languages = "*",
+        $Languages = @("*"),
 
         [Parameter()]
         [System.String[]]
@@ -745,7 +745,7 @@ function Test-TargetResource
 
         [Parameter()]
         [System.String[]]
-        $Languages = "*",
+        $Languages = @("*"),
 
         [Parameter()]
         [System.String[]]

--- a/DSCResources/MSFT_UpdateServicesServer/MSFT_UpdateServicesServer.psm1
+++ b/DSCResources/MSFT_UpdateServicesServer/MSFT_UpdateServicesServer.psm1
@@ -464,7 +464,7 @@ function Set-TargetResource
         }
 
         #ClientTargetingMode
-        if($PSBoundParameters.ContainsKey("Client Targeting Mode"))
+        if($PSBoundParameters.ContainsKey("ClientTargetingMode"))
         {
             Write-Verbose -Message "Setting WSUS client targeting mode"
             $WsusConfiguration.TargetingMode = $ClientTargetingMode

--- a/Tests/Integration/UpdateServicesConfig.ps1
+++ b/Tests/Integration/UpdateServicesConfig.ps1
@@ -26,7 +26,7 @@ Configuration UpdateServicesConfig
                 )
                 Ensure = 'Present'
                 ContentDir = 'C:\WSUS'
-                Languages = 'en'
+                Languages = @('en','fr','es')
                 Products = @(
                     'Forefront Endpoint Protection 2010',
                     'Windows Server 2012 R2'


### PR DESCRIPTION
#### Pull Request (PR) description
(Issue-36) Correct Multiple Language Comparison

Ensure that WSUS.Languages is returned as an array of strings to allow
multiple languages to be compared correctly in Test-TargetResource

Thanks to @RandomNoun for assistance debugging/preparing this PR.

#### This Pull Request (PR) fixes the following issues

See #36 for a full description of the problem.
```UpdateServicesServer``` was failing to configure WSUS if more than one Update Language was set.

#### Task list
- [x] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [-] Resource documentation added/updated in README.md.
- [-] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [-] Comment-based help added/updated.
- [-] Localization strings added/updated in all localization files as appropriate.
- [-] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [-] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).
