### PR TITLE
[UpdateServicesServer] Add IGNORE option to UpstreamServerName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Updated inital offline package sync WSUS.cab.
+- Added IGNORE option for UpstreamServerName to prevent it being changed when SCCM is managing the upstream source
 
 ## [1.2.0] - 2020-05-18
 

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -93,7 +93,7 @@ Windows Server 2008 R2 SP1, Windows Server 2012 and Windows Server 2012 R2.
 * **SQLServer**: SQL Server for the WSUS database, omit for Windows Internal Database.
 * **ContentDir**: Folder for WSUS update files.
 * **UpdateImprovementProgram**: Join the Microsoft Update Improvement Program.
-* **UpstreamServerName**: Upstream WSUS server, omit for Microsoft Update.
+* **UpstreamServerName**: Upstream WSUS server, omit for Microsoft Update. Set to 'IGNORE' to prevent changes being made, for example in a SCCM environment
 * **UpstreamServerPort**: Port of upstream WSUS server.
 * **UpstreamServerSSL**: Use SSL with upstream WSUS server.
 * **UpstreamServerReplica**: Replica of upstream WSUS server.

--- a/Tests/Unit/MSFT_UpdateServicesServer.tests.ps1
+++ b/Tests/Unit/MSFT_UpdateServicesServer.tests.ps1
@@ -221,27 +221,27 @@ try
 
                 Mock -CommandName Get-TargetResource -MockWith {
                     $GetValues = $DSCTestValues
-					$GetValues.Remove('UpstreamServerName')
-					$GetValues.Add('UpstreamServerName', 'SomeOtherServer')
-					$GetValues
+                    $GetValues.Remove('UpstreamServerName')
+                    $GetValues.Add('UpstreamServerName', 'SomeOtherServer')
+                    $GetValues
                 } -Verifiable
 
                 $script:result = $null
 
-				It "calling test with change to UpstreamServerName should not throw" {
-					{ $script:result = Test-TargetResource @DSCTestValues -verbose } | Should not throw
-				}
+                It "calling test with change to UpstreamServerName should not throw" {
+                    { $script:result = Test-TargetResource @DSCTestValues -verbose } | Should not throw
+                }
 
-				It "result should be true, even when UpstreamServerName is different" {
-					$script:result | Should be $true
-				}
+                It "result should be true, even when UpstreamServerName is different" {
+                    $script:result | Should be $true
+                }
 
-				It 'mocks were called' {
-					Assert-VerifiableMock
-				}
+                It 'mocks were called' {
+                    Assert-VerifiableMock
+                }
 
-				$DSCTestValues.Remove('UpstreamServerName')
-				$DSCTestValues.Add('UpstreamServerName', 'UpstreamServer')
+                $DSCTestValues.Remove('UpstreamServerName')
+                $DSCTestValues.Add('UpstreamServerName', 'UpstreamServer')
                 }
             }
         #endregion

--- a/Tests/Unit/MSFT_UpdateServicesServer.tests.ps1
+++ b/Tests/Unit/MSFT_UpdateServicesServer.tests.ps1
@@ -214,7 +214,36 @@ try
                 }
             }
 
-        }
+            Context "upstream server difference is ignored" {
+
+                $DSCTestValues.Remove('UpstreamServerName')
+                $DSCTestValues.Add('UpstreamServerName', 'IGNORE')
+
+                Mock -CommandName Get-TargetResource -MockWith {
+                    $GetValues = $DSCTestValues
+					$GetValues.Remove('UpstreamServerName')
+					$GetValues.Add('UpstreamServerName', 'SomeOtherServer')
+					$GetValues
+                } -Verifiable
+
+                $script:result = $null
+
+				It "calling test with change to UpstreamServerName should not throw" {
+					{ $script:result = Test-TargetResource @DSCTestValues -verbose } | Should not throw
+				}
+
+				It "result should be true, even when UpstreamServerName is different" {
+					$script:result | Should be $true
+				}
+
+				It 'mocks were called' {
+					Assert-VerifiableMock
+				}
+
+				$DSCTestValues.Remove('UpstreamServerName')
+				$DSCTestValues.Add('UpstreamServerName', 'UpstreamServer')
+                }
+            }
         #endregion
 
         #region Function Set-TargetResource

--- a/source/DSCResources/MSFT_UpdateServicesServer/MSFT_UpdateServicesServer.psm1
+++ b/source/DSCResources/MSFT_UpdateServicesServer/MSFT_UpdateServicesServer.psm1
@@ -849,7 +849,8 @@ function Test-TargetResource
         }
 
         # Test Upstream Server
-        if ($Wsus.UpstreamServerName -ne $UpstreamServerName)
+
+		if ($Wsus.UpstreamServerName -ne $UpstreamServerName -and $UpstreamServerName -ne "IGNORE")
         {
             Write-Verbose -Message $script:localizedData.UpstreamNameTestFailed
             $result = $false

--- a/source/DSCResources/MSFT_UpdateServicesServer/MSFT_UpdateServicesServer.psm1
+++ b/source/DSCResources/MSFT_UpdateServicesServer/MSFT_UpdateServicesServer.psm1
@@ -850,7 +850,7 @@ function Test-TargetResource
 
         # Test Upstream Server
 
-		if ($Wsus.UpstreamServerName -ne $UpstreamServerName -and $UpstreamServerName -ne "IGNORE")
+        if ($Wsus.UpstreamServerName -ne $UpstreamServerName -and $UpstreamServerName -ne "IGNORE")
         {
             Write-Verbose -Message $script:localizedData.UpstreamNameTestFailed
             $result = $false


### PR DESCRIPTION
#### Pull Request (PR) description
Allows the UpstreamServerName value to be set to IGNORE, allowing the check to be skipped where the upstream server should neither be Microsoft Update, nor managed by DSC. Example use is with SCCM Software Update Point. 

#### This Pull Request (PR) fixes the following issues
Fixes #55 

#### Task list
- [x] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [x] Resource documentation added/updated in README.md.
- [x] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [x] Comment-based help added/updated.
- [x] Localization strings added/updated in all localization files as appropriate.
- [x] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/updateservicesdsc/56)
<!-- Reviewable:end -->
