### PR TITLE
Fix issue #62 and #63, fix verbose message and type variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   of pipeline artifact
 - Updated build.ps1 script and build.yaml.
 - Changed default timeout in Wait-Win32ProcessStart function for cab installation.
+- Updated ReadMe.md to removed `RunRuleNow` parameter.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 multiple products dor the same `Title`.
 - Fix issue #58 and #66, with removed `-ErrorRecord` parameter on `New-InvalidResultException`
  because `$_` not contain an exception.
+- Fix issue [#62](https://github.com/dsccommunity/UpdateServicesDsc/issues/62),
+ Fixed verbose output of Languages in UpdateServiceServer
+- Fix issue [#63](https://github.com/dsccommunity/UpdateServicesDsc/issues/63),
+ Fixed verbose output of WSUS server in UpdateServicesApprovalRule
 
 ## [1.2.0] - 2020-05-18
 

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -109,7 +109,6 @@ Windows Server 2008 R2 SP1, Windows Server 2012 and Windows Server 2012 R2.
 * **SynchronizeAutomaticallyTimeOfDay**: First synchronization.
 * **SynchronizationsPerDay**: Synchronizations per day.
 * **Synchronize**: Begin initial synchronization.
-* **RunRuleNow**: Run Approval Rule on existing content.
 * **ClientTargetingMode**: An enumerated value that describes if how the Target Groups are populated.
 
 ## Versions

--- a/source/DSCResources/MSFT_UpdateServicesApprovalRule/MSFT_UpdateServicesApprovalRule.psm1
+++ b/source/DSCResources/MSFT_UpdateServicesApprovalRule/MSFT_UpdateServicesApprovalRule.psm1
@@ -52,7 +52,7 @@ function Get-TargetResource
 
         if ($null -ne $WsusServer)
         {
-            Write-Verbose -Message ('Identified WSUS server information: {0}' -f $WsusServer)
+            Write-Verbose -Message ('Identified WSUS server information: {0}' -f $WsusServer.Name)
 
             $ApprovalRule = $WsusServer.GetInstallApprovalRules() | Where-Object -FilterScript { $_.Name -eq $Name }
 

--- a/source/DSCResources/MSFT_UpdateServicesServer/MSFT_UpdateServicesServer.psm1
+++ b/source/DSCResources/MSFT_UpdateServicesServer/MSFT_UpdateServicesServer.psm1
@@ -121,7 +121,7 @@ function Get-TargetResource
         }
         else
         {
-            $Languages = $WsusConfiguration.GetEnabledUpdateLanguages()
+            $Languages = ($WsusConfiguration.GetEnabledUpdateLanguages()) -join ','
         }
 
         Write-Verbose -Message ($script:localizedData.WsusLanguages -f $Languages)
@@ -141,9 +141,9 @@ function Get-TargetResource
 
         Write-Verbose -Message ($script:localizedData.WsusClassifications -f $Classifications)
         Write-Verbose -Message $script:localizedData.GettingWsusProducts
-        if ($Products = @($WsusSubscription.GetUpdateCategories().Title))
+        if ($Products = @($WsusSubscription.GetUpdateCategories().Title) | Sort-Object -Unique)
         {
-            if ($null -eq (Compare-Object -ReferenceObject ($Products | Sort-Object -Unique) -DifferenceObject `
+            if ($null -eq (Compare-Object -ReferenceObject $Products -DifferenceObject `
                     (($WsusServer.GetUpdateCategories().Title) | Sort-Object -Unique) -SyncWindow 0))
             {
                 $Products = @('*')
@@ -581,9 +581,9 @@ if ($WsusConfiguration.OobeInitialized)
         # All Products
         '*' {
             Write-Verbose -Message $script:localizedData.ConfiguringAllProducts
-            foreach ($Prdct in $AllWsusProducts)
+            foreach ($prdct in $AllWsusProducts)
             {
-                $null = $productCollection.Add($WsusServer.GetUpdateCategory($Prdct.Id))
+                $null = $productCollection.Add($WsusServer.GetUpdateCategory($prdct.Id))
             }
             continue
         }


### PR DESCRIPTION
#### Pull Request (PR) description

This PR fixes two Verbose message.
And Updated ReadMe.md to removed `RunRuleNow` parameter.

#### This Pull Request (PR) fixes the following issues

- Fixes issue #62
- Fixes issue #63

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->
- [x] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [x] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/updateservicesdsc/72)
<!-- Reviewable:end -->
